### PR TITLE
Increased flexibility with argparse

### DIFF
--- a/silly_walks.py
+++ b/silly_walks.py
@@ -1,6 +1,5 @@
 # 1/usr/bin/env python
 
-import sys
 from rdkit import Chem
 from rdkit.Chem import AllChem
 import pandas as pd

--- a/silly_walks.py
+++ b/silly_walks.py
@@ -7,8 +7,7 @@ import pandas as pd
 
 
 class SillyWalks:
-    def __init__(self, ref_filename):
-        df = pd.read_csv(ref_filename, sep=" ", names=["SMILES", "Name"])
+    def __init__(self, df):
         self.count_dict = {}
         for smi in df.SMILES:
             mol = Chem.MolFromSmiles(smi)
@@ -22,7 +21,9 @@ class SillyWalks:
         if mol:
             fp = AllChem.GetMorganFingerprint(mol, 2)
             on_bits = fp.GetNonzeroElements().keys()
-            silly_bits = [x for x in [self.count_dict.get(x) for x in on_bits] if x is None]
+            silly_bits = [
+                x for x in [self.count_dict.get(x) for x in on_bits] if x is None
+            ]
             score = len(silly_bits) / len(on_bits)
         else:
             score = 1
@@ -30,9 +31,40 @@ class SillyWalks:
 
 
 if __name__ == "__main__":
-    infile_name = sys.argv[1]
-    df = pd.read_csv(infile_name)
-    silly_walks = SillyWalks("chembl_drugs.smi")
-    df['silly'] = df.SMILES.apply(silly_walks.score)
-    df.sort_values('silly', ascending=False, inplace=True)
-    print(df.head())
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Silly Walks")
+
+    parser.add_argument("smiles", type=str, help="CSV file with SMILES")
+    parser.add_argument(
+        "-s", "--smiles_col", default="SMILES", type=str, help="SMILES column name"
+    )
+    parser.add_argument(
+        "--sep", default=",", type=str, help="Column separator in input file"
+    )
+    parser.add_argument(
+        "-r", "--reference", default="chembl_drugs.smi", type=str, help="Reference file"
+    )
+    parser.add_argument(
+        "--strip_out",
+        action="store_true",
+        help="Output only SMILES and sillyness score",
+    )
+    parser.add_argument("-o", "--out", default="silly.csv", type=str, help="Output")
+
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.smiles, sep=args.sep)
+    df_ref = pd.read_csv(
+        args.reference, sep=" ", names=["SMILES", "Name"]
+    )  # TODO: Generalize?
+
+    silly_walks = SillyWalks(df_ref)
+
+    df["silly"] = df[args.smiles_col].apply(silly_walks.score)
+    df.sort_values("silly", ascending=False, inplace=True)
+
+    if args.strip_out:
+        df[[args.smiles_col, "silly"]].to_csv(args.out, index=False)
+    else:
+        df.to_csv(args.out, index=False, float_format="%.3f")


### PR DESCRIPTION
I added `argparse` in order to increase the flexibility of the script when called from the command line. The following is made possible in this PR (loosely tested):
* Select SMILES column name in input file with `--smiles_col`
* Select column separator in input file with `--sep`
* Select reference file with `--reference` (structure assumed to be the same as `chembl_drugs.smi`; this could be improved)
* Output data frame with silliness score to file with `--out`
* Output only SMILES and silliness score with `--strip_out`